### PR TITLE
Feature/33 export data to excel

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@testing-library/react": "^14.2.1",
 		"axios": "^1.6.7",
 		"eslint-config-prettier": "^9.1.0",
+		"export-from-json": "^1.7.4",
 		"jest": "^29.7.0",
 		"jest-environment-jsdom": "^29.7.0",
 		"next": "14.1.0",
@@ -52,5 +53,5 @@
 		"moduleNameMapper": {
 			"\\.(css|less)$": "<rootDir>/transformerCSS.js"
 		}
-    }
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   eslint-config-prettier:
     specifier: ^9.1.0
     version: 9.1.0(eslint@8.56.0)
+  export-from-json:
+    specifier: ^1.7.4
+    version: 1.7.4
   jest:
     specifier: ^29.7.0
     version: 29.7.0
@@ -3369,6 +3372,10 @@ packages:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+    dev: false
+
+  /export-from-json@1.7.4:
+    resolution: {integrity: sha512-FjmpluvZS2PTYyhkoMfQoyEJMfe2bfAyNpa5Apa6C9n7SWUWyJkG/VFnzERuj3q9Jjo3iwBjwVsDQ7Z7sczthA==}
     dev: false
 
   /fast-deep-equal@3.1.3:

--- a/public/excel.svg
+++ b/public/excel.svg
@@ -1,0 +1,7 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg fill="#ffffff" height="800px" width="800px" version="1.1" id="XMLID_44_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 24 24" xml:space="preserve" stroke="#ffffff">
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+<g id="SVGRepo_iconCarrier"> <g id="document-excel"> <g> <polygon points="23,24 3,24 3,22 21,22 21,6.4 16.6,2 5,2 5,9 3,9 3,0 17.4,0 23,5.6 "/> </g> <g> <polygon points="22,8 15,8 15,2 17,2 17,6 22,6 "/> </g> <g> <path d="M4.8,15.4l-3-4.4h2.3L6,13.9L7.9,11h2.3l-3,4.4l3.1,4.6H8l-2-3.1L4,20H1.7L4.8,15.4z"/> </g> </g> </g>
+</svg>

--- a/src/app/beneficiaries/page.jsx
+++ b/src/app/beneficiaries/page.jsx
@@ -33,7 +33,14 @@ export default async function BeneficiariesList() {
 			<div className="h-12 w-max top-28 absolute flex flex-row">
 				<button
 					className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2"
-					onClick={() => exportData(data, 'Beneficiados')}
+					onClick={() =>
+						exportData(data, 'Beneficiados', [
+							'id',
+							'alias',
+							'birthday',
+							'isFinished'
+						])
+					}
 				>
 					<Image
 						src="/excel.svg"

--- a/src/app/beneficiaries/page.jsx
+++ b/src/app/beneficiaries/page.jsx
@@ -14,7 +14,7 @@ export default async function BeneficiariesList() {
 	return (
 		<div className='max-w-fit'>
 			<div className="h-12 w-12 top-28 absolute" >
-						<button className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2" onClick={()=>exportData(data,'Familias')}>
+						<button className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2" onClick={()=>exportData(data,'Beneficiados')}>
 							<Image
 								src="/excel.svg"
 								className="ml-2"

--- a/src/app/beneficiaries/page.jsx
+++ b/src/app/beneficiaries/page.jsx
@@ -41,6 +41,7 @@ export default async function BeneficiariesList() {
 							'isFinished'
 						])
 					}
+					data-testid="export-button"
 				>
 					<Image
 						src="/excel.svg"

--- a/src/app/beneficiaries/page.jsx
+++ b/src/app/beneficiaries/page.jsx
@@ -8,28 +8,61 @@ import Card from './card.jsx'
 import { fetchDataBeneficiaries } from './fetch.js'
 import Image from 'next/image.js'
 import exportData from '../exportData.js'
+import axios from 'axios'
 
 export default async function BeneficiariesList() {
 	const data = await fetchDataBeneficiaries()
+	const handleFileChange = async event => {
+		const selectedFile = event.target.files[0]
+		try {
+			const formData = new FormData()
+			formData.append('file', selectedFile)
+			await axios.post('url/de/import', formData, {
+				headers: {
+					'Content-Type': 'multipart/form-data'
+				}
+			})
+			alert('Datos importados correctamente')
+		} catch (error) {
+			console.error(error)
+			alert('Error al importar los datos')
+		}
+	}
 	return (
-		<div className='max-w-fit'>
-			<div className="h-12 w-12 top-28 absolute" >
-						<button className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2" onClick={()=>exportData(data,'Beneficiados')}>
-							<Image
-								src="/excel.svg"
-								className="ml-2"
-								width={15}
-								height={15}>	
-							</Image>
-						</button>
-					</div>
-		<div className=" grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
-			{data.map(beneficiary => (
-				<Link href={`/beneficiaries/${beneficiary.id}`} key={beneficiary.id}>
-					<Card key={beneficiary.id} beneficiary={beneficiary} />
-				</Link>
-			))}
-		</div>
+		<div className="max-w-fit">
+			<div className="h-12 w-max top-28 absolute flex flex-row">
+				<button
+					className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2"
+					onClick={() => exportData(data, 'Beneficiados')}
+				>
+					<Image
+						src="/excel.svg"
+						className="ml-2"
+						width={15}
+						height={15}
+					></Image>
+				</button>
+				<label
+					htmlFor="file"
+					className="bg-green-400 w-32 h-6 mt-4 rounded-full font-Varela text-white cursor-pointer text-center text-sm"
+				>
+					Importar datos
+				</label>
+				<input
+					type="file"
+					id="file"
+					onChange={handleFileChange}
+					style={{ display: 'none' }}
+					accept=".xls"
+				/>
+			</div>
+			<div className=" grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
+				{data.map(beneficiary => (
+					<Link href={`/beneficiaries/${beneficiary.id}`} key={beneficiary.id}>
+						<Card key={beneficiary.id} beneficiary={beneficiary} />
+					</Link>
+				))}
+			</div>
 		</div>
 	)
 }

--- a/src/app/beneficiaries/page.jsx
+++ b/src/app/beneficiaries/page.jsx
@@ -1,19 +1,35 @@
+'use client'
+
 /* eslint-disable no-unused-vars */
 import React from 'react'
 /* eslint-enable no-unused-vars */
 import Link from 'next/link.js'
 import Card from './card.jsx'
 import { fetchDataBeneficiaries } from './fetch.js'
+import Image from 'next/image.js'
+import exportData from '../exportData.js'
 
 export default async function BeneficiariesList() {
 	const data = await fetchDataBeneficiaries()
 	return (
-		<div className="max-w-fit grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
+		<div className='max-w-fit'>
+			<div className="h-12 w-12 top-28 absolute" >
+						<button className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2" onClick={()=>exportData(data,'Familias')}>
+							<Image
+								src="/excel.svg"
+								className="ml-2"
+								width={15}
+								height={15}>	
+							</Image>
+						</button>
+					</div>
+		<div className=" grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
 			{data.map(beneficiary => (
 				<Link href={`/beneficiaries/${beneficiary.id}`} key={beneficiary.id}>
 					<Card key={beneficiary.id} beneficiary={beneficiary} />
 				</Link>
 			))}
+		</div>
 		</div>
 	)
 }

--- a/src/app/exportData.js
+++ b/src/app/exportData.js
@@ -1,0 +1,11 @@
+import exportFromJSON from 'export-from-json'
+
+function exportData(datos, nombre) {
+	exportFromJSON({
+		data: datos,
+		fileName: nombre,
+		exportType: exportFromJSON.types.xls
+	})
+}
+
+export default exportData

--- a/src/app/exportData.js
+++ b/src/app/exportData.js
@@ -1,10 +1,11 @@
 import exportFromJSON from 'export-from-json'
 
-function exportData(datos, nombre) {
+function exportData(datos, nombre, columnas) {
 	exportFromJSON({
 		data: datos,
 		fileName: nombre,
-		exportType: exportFromJSON.types.xls
+		exportType: exportFromJSON.types.xls,
+		fields: columnas
 	})
 }
 

--- a/src/app/interventions/InterventionList.jsx
+++ b/src/app/interventions/InterventionList.jsx
@@ -7,25 +7,61 @@ import Link from 'next/link.js'
 import { fetchDataInterventions } from './fetch.jsx'
 import Image from 'next/image'
 import exportData from '../exportData'
+import axios from 'axios'
 
 export default async function InterventionList() {
+	const handleFileChange = async event => {
+		const selectedFile = event.target.files[0]
+		try {
+			const formData = new FormData()
+			formData.append('file', selectedFile)
+			await axios.post('url/de/import', formData, {
+				headers: {
+					'Content-Type': 'multipart/form-data'
+				}
+			})
+			alert('Datos importados correctamente')
+		} catch (error) {
+			console.error(error)
+			alert('Error al importar los datos')
+		}
+	}
 	const data = await fetchDataInterventions()
 	return (
-		<div className='max-w-fit'>
-			<div className="h-12 w-12 top-28 absolute" >
-						<button className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2" onClick={()=>exportData(data,'Intervenciones')}>
-							<Image
-								src="/excel.svg"
-								className="ml-2"
-								width={15}
-								height={15}>	
-							</Image>
-						</button>
-					</div>
+		<div className="max-w-fit">
+			<div className="h-12 w-max top-28 absolute flex flex-row">
+				<button
+					className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2"
+					onClick={() => exportData(data, 'Intervenciones')}
+				>
+					<Image
+						src="/excel.svg"
+						className="ml-2"
+						width={15}
+						height={15}
+					></Image>
+				</button>
+				<label
+					htmlFor="file"
+					className="bg-green-400 w-32 h-6 mt-4 rounded-full font-Varela text-white cursor-pointer text-center text-sm"
+				>
+					Importar datos
+				</label>
+				<input
+					type="file"
+					id="file"
+					onChange={handleFileChange}
+					style={{ display: 'none' }}
+					accept=".xls"
+				/>
+			</div>
 			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
 				{data.map(intervention => (
 					<Link href={'interventions'} key={intervention.id}>
-						<InterventionCard key={intervention.id} intervention={intervention} />
+						<InterventionCard
+							key={intervention.id}
+							intervention={intervention}
+						/>
 					</Link>
 				))}
 			</div>

--- a/src/app/interventions/InterventionList.jsx
+++ b/src/app/interventions/InterventionList.jsx
@@ -1,19 +1,34 @@
+'use client'
 /* eslint-disable no-unused-vars */
 import React from 'react'
 /* eslint-enable no-unused-vars */
 import InterventionCard from './InterventionCard'
 import Link from 'next/link.js'
 import { fetchDataInterventions } from './fetch.jsx'
+import Image from 'next/image'
+import exportData from '../exportData'
 
 export default async function InterventionList() {
 	const data = await fetchDataInterventions()
 	return (
-		<div className="max-w-fit grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
-			{data.map(intervention => (
-				<Link href={'interventions'} key={intervention.id}>
-					<InterventionCard key={intervention.id} intervention={intervention} />
-				</Link>
-			))}
+		<div className='max-w-fit'>
+			<div className="h-12 w-12 top-28 absolute" >
+						<button className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2" onClick={()=>exportData(data,'Intervenciones')}>
+							<Image
+								src="/excel.svg"
+								className="ml-2"
+								width={15}
+								height={15}>	
+							</Image>
+						</button>
+					</div>
+			<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-7 overflow-y-scroll relative top-28">
+				{data.map(intervention => (
+					<Link href={'interventions'} key={intervention.id}>
+						<InterventionCard key={intervention.id} intervention={intervention} />
+					</Link>
+				))}
+			</div>
 		</div>
 	)
 }

--- a/src/app/interventions/InterventionList.jsx
+++ b/src/app/interventions/InterventionList.jsx
@@ -33,6 +33,7 @@ export default async function InterventionList() {
 				<button
 					className=" bg-green-400 h-8 w-8 rounded-full shadow-2xl mt-3 mr-2"
 					onClick={() => exportData(data, 'Intervenciones')}
+					data-testid="export-button"
 				>
 					<Image
 						src="/excel.svg"

--- a/src/app/interventions/page.jsx
+++ b/src/app/interventions/page.jsx
@@ -1,3 +1,4 @@
+'use client'
 import InterventionList from './InterventionList'
 
 export default function AppointmentsPage() { 

--- a/src/test/beneficiaries/beneficiariesImportExport.test.jsx
+++ b/src/test/beneficiaries/beneficiariesImportExport.test.jsx
@@ -1,0 +1,65 @@
+/* eslint-disable no-unused-vars */
+import React from 'react'
+/* eslint-enable no-unused-vars */
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import axios from 'axios' // Mock axios
+import BeneficiariesList from '../../app/beneficiaries/page.jsx'
+import { fetchDataBeneficiaries } from '../../app/beneficiaries/fetch.js'
+import { exportData } from '../../app/exportData.js'
+import { test, expect, describe, jest } from '@jest/globals'
+
+// Mocking axios post function
+jest.mock('axios')
+jest.mock('../../app/beneficiaries/fetch.js')
+
+describe('BeneficiariesList', () => {
+	test('export button', () => {
+		const mockData = [
+			{ id: 1, name: 'John Doe' },
+			{ id: 2, name: 'Jane Doe' }
+		]
+		fetchDataBeneficiaries.mockResolvedValue(mockData)
+
+		waitFor(async () => {
+			const { getByTestId } = render(<BeneficiariesList />)
+
+			const exportButton = getByTestId('export-button')
+			fireEvent.click(exportButton)
+
+			// Ensure exportData is called with correct arguments
+			expect(exportData).toHaveBeenCalledWith(mockData, 'Beneficiados')
+		})
+	})
+
+	test('import button', async () => {
+		const mockData = [
+			{ id: 1, name: 'John Doe' },
+			{ id: 2, name: 'Jane Doe' }
+		]
+
+		// Mocking fetchDataFoods function
+		fetchDataBeneficiaries.mockResolvedValue(mockData)
+
+		waitFor(async () => {
+			render(<BeneficiariesList />)
+
+			fireEvent.click(screen.getByLabelText('Importar datos'))
+
+			// Ensure axios.post is called with correct arguments
+			expect(axios.post).toHaveBeenCalledWith(
+				'url/de/import',
+				expect.any(FormData),
+				{ headers: { 'Content-Type': 'multipart/form-data' } }
+			)
+
+			// Simulate error during import
+			axios.post.mockRejectedValueOnce(new Error('Some error'))
+
+			fireEvent.change(screen.getByLabelText('file'), {
+				target: { files: [new File(['test.xls'], 'test.xls')] }
+			})
+
+			await screen.findByText('Error al importar los datos')
+		})
+	})
+})

--- a/src/test/interventions/interventionsImportExport.test.jsx
+++ b/src/test/interventions/interventionsImportExport.test.jsx
@@ -1,0 +1,73 @@
+/* eslint-disable no-unused-vars */
+import React from 'react'
+/* eslint-enable no-unused-vars */
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import axios from 'axios' // Mock axios
+import InterventionList from '../../app/interventions/InterventionList.jsx'
+import { fetchDataInterventions } from '../../app/interventions/fetch.jsx'
+import { exportData } from '../../app/exportData.js'
+import { test, expect, describe, jest } from '@jest/globals'
+
+// Mocking axios post function
+jest.mock('axios')
+jest.mock('../../app/interventions/fetch.jsx')
+
+describe('InterventionsList', () => {
+	test('export button', () => {
+		const mockData = [
+			{
+				id: 1,
+				intervention_date: '2018-05-08T16:29:31.591Z',
+				patient: 'John Doe'
+			},
+			{
+				id: 2,
+				intervention_date: '2018-05-08T16:29:31.591Z',
+				patient: 'Jane Doe'
+			}
+		]
+		fetchDataInterventions.mockResolvedValue(mockData)
+
+		waitFor(async () => {
+			const { getByTestId } = render(<InterventionList />)
+
+			const exportButton = getByTestId('export-button')
+			fireEvent.click(exportButton)
+
+			// Ensure exportData is called with correct arguments
+			expect(exportData).toHaveBeenCalledWith(mockData, 'Intervenciones')
+		})
+	})
+
+	test('import button', async () => {
+		const mockData = [
+			{ id: 1, name: 'John Doe' },
+			{ id: 2, name: 'Jane Doe' }
+		]
+
+		// Mocking fetchDataFoods function
+		fetchDataInterventions.mockResolvedValue(mockData)
+
+		waitFor(async () => {
+			render(<InterventionList />)
+
+			fireEvent.click(screen.getByLabelText('Importar datos'))
+
+			// Ensure axios.post is called with correct arguments
+			expect(axios.post).toHaveBeenCalledWith(
+				'url/de/import',
+				expect.any(FormData),
+				{ headers: { 'Content-Type': 'multipart/form-data' } }
+			)
+
+			// Simulate error during import
+			axios.post.mockRejectedValueOnce(new Error('Some error'))
+
+			fireEvent.change(screen.getByLabelText('file'), {
+				target: { files: [new File(['test.xls'], 'test.xls')] }
+			})
+
+			await screen.findByText('Error al importar los datos')
+		})
+	})
+})


### PR DESCRIPTION
# Description

The possibility of exporting all beneficiary and intervention data to an excel file has been added for data management.
I am aware that there are certain beneficiary data that look very ugly, but no literal ones like that. It's not that they have a bad export or anything, it's just that these are the data. I've left an image of what it looks like on the console.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

# Screenshot(If applies):
![Captura de pantalla 2024-03-07 115303](https://github.com/ISPP-07/frontend-acat/assets/73543896/c8750638-fee0-476e-8941-ed3ce4437533)

