### PR TITLE
Fix/50 searchbar modal button

### DIFF
--- a/src/app/components/searchbar.jsx
+++ b/src/app/components/searchbar.jsx
@@ -27,7 +27,11 @@ const Searchbar = ({
 				</div>
 				<ButtonIcon color={'bg-blue-500'} iconpath={'/filter.svg'} />
 				<div className="lg:hidden block">
-					<ButtonIcon color={'bg-[#75AF73]'} iconpath={'/plus.svg'} />
+					<ButtonIcon
+						color={'bg-[#75AF73]'}
+						handleClick={handleClick}
+						iconpath={'/plus.svg'}
+					/>
 				</div>
 				<div className="lg:block hidden">
 					<ButtonText


### PR DESCRIPTION
# Description

In mobile, the button in the searchbar would not open the modal, this is because the prop handleClick was not inclueded in the element. This fix includes said prop.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes