### PR TITLE
feat: Add connection of interventions to the backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
 NEXT_PUBLIC_BASE_URL= "http://127.0.0.1:8080/api/v1"
-NEXT_PUBLIC_BASE_URL= "http://127.0.0.1:8080/api/v1"

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.env
 
 # vercel
 .vercel

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"react": "^18",
 		"react-dom": "^18",
 		"react-router-dom": "^6.22.1",
+		"react-select": "^5.8.0",
 		"react-test-renderer": "^18.2.0"
 	},
 	"devDependencies": {
@@ -37,8 +38,8 @@
 		"eslint-plugin-import": "^2.25.2",
 		"eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
 		"eslint-plugin-promise": "^6.0.0",
-		"export-from-json": "^1.7.4",
 		"eslint-plugin-react": "^7.33.2",
+		"export-from-json": "^1.7.4",
 		"jest": "^29.7.0",
 		"jest-environment-jsdom": "^29.7.0",
 		"postcss": "^8",
@@ -58,5 +59,5 @@
 			"/node_modules/",
 			"/src/app/components/icons/"
 		]
-    }
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   react-router-dom:
     specifier: ^6.22.1
     version: 6.22.2(react-dom@18.2.0)(react@18.2.0)
+  react-select:
+    specifier: ^5.8.0
+    version: 5.8.0(react-dom@18.2.0)(react@18.2.0)
   react-test-renderer:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
@@ -1330,6 +1333,94 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: false
 
+  /@emotion/babel-plugin@11.11.0:
+    resolution: {integrity: sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==}
+    dependencies:
+      '@babel/helper-module-imports': 7.22.15
+      '@babel/runtime': 7.23.9
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/serialize': 1.1.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    dev: false
+
+  /@emotion/cache@11.11.0:
+    resolution: {integrity: sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==}
+    dependencies:
+      '@emotion/memoize': 0.8.1
+      '@emotion/sheet': 1.2.2
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      stylis: 4.2.0
+    dev: false
+
+  /@emotion/hash@0.9.1:
+    resolution: {integrity: sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==}
+    dev: false
+
+  /@emotion/memoize@0.8.1:
+    resolution: {integrity: sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA==}
+    dev: false
+
+  /@emotion/react@11.11.4(react@18.2.0):
+    resolution: {integrity: sha512-t8AjMlF0gHpvvxk5mAtCqR4vmxiGHCeJBaQO6gncUSdklELOgtwjerNY2yuJNfwnc6vi16U/+uMF+afIawJ9iw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/babel-plugin': 11.11.0
+      '@emotion/cache': 11.11.0
+      '@emotion/serialize': 1.1.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1(react@18.2.0)
+      '@emotion/utils': 1.2.1
+      '@emotion/weak-memoize': 0.3.1
+      hoist-non-react-statics: 3.3.2
+      react: 18.2.0
+    dev: false
+
+  /@emotion/serialize@1.1.3:
+    resolution: {integrity: sha512-iD4D6QVZFDhcbH0RAG1uVu1CwVLMWUkCvAqqlewO/rxf8+87yIBAlt4+AxMiiKPLs5hFc0owNk/sLLAOROw3cA==}
+    dependencies:
+      '@emotion/hash': 0.9.1
+      '@emotion/memoize': 0.8.1
+      '@emotion/unitless': 0.8.1
+      '@emotion/utils': 1.2.1
+      csstype: 3.1.3
+    dev: false
+
+  /@emotion/sheet@1.2.2:
+    resolution: {integrity: sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA==}
+    dev: false
+
+  /@emotion/unitless@0.8.1:
+    resolution: {integrity: sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==}
+    dev: false
+
+  /@emotion/use-insertion-effect-with-fallbacks@1.0.1(react@18.2.0):
+    resolution: {integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==}
+    peerDependencies:
+      react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
+    dev: false
+
+  /@emotion/utils@1.2.1:
+    resolution: {integrity: sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==}
+    dev: false
+
+  /@emotion/weak-memoize@0.3.1:
+    resolution: {integrity: sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww==}
+    dev: false
+
   /@eslint-community/eslint-utils@4.4.0(eslint@8.56.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -1362,6 +1453,23 @@ packages:
   /@eslint/js@8.56.0:
     resolution: {integrity: sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  /@floating-ui/core@1.6.0:
+    resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
+    dependencies:
+      '@floating-ui/utils': 0.2.1
+    dev: false
+
+  /@floating-ui/dom@1.6.3:
+    resolution: {integrity: sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==}
+    dependencies:
+      '@floating-ui/core': 1.6.0
+      '@floating-ui/utils': 0.2.1
+    dev: false
+
+  /@floating-ui/utils@0.2.1:
+    resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
+    dev: false
 
   /@humanwhocodes/config-array@0.11.14:
     resolution: {integrity: sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==}
@@ -1917,12 +2025,22 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
+  /@types/parse-json@4.0.2:
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+    dev: false
+
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
     dev: false
 
   /@types/react-dom@18.2.19:
     resolution: {integrity: sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==}
+    dependencies:
+      '@types/react': 18.2.57
+    dev: false
+
+  /@types/react-transition-group@4.4.10:
+    resolution: {integrity: sha512-hT/+s0VQs2ojCX823m60m5f0sL5idt9SO6Tj6Dg+rdphGPIeJbJ6CxvBYkgkGKrYeDjvIpKTR38UzmtHJOGW3Q==}
     dependencies:
       '@types/react': 18.2.57
     dev: false
@@ -2322,6 +2440,15 @@ packages:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.5
 
+  /babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+    dependencies:
+      '@babel/runtime': 7.23.9
+      cosmiconfig: 7.1.0
+      resolve: 1.22.8
+    dev: false
+
   /babel-plugin-polyfill-corejs2@0.4.8(@babel/core@7.23.9):
     resolution: {integrity: sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==}
     peerDependencies:
@@ -2586,6 +2713,10 @@ packages:
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  /convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+    dev: false
+
   /convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2594,6 +2725,17 @@ packages:
     dependencies:
       browserslist: 4.23.0
     dev: true
+
+  /cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.0
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
+    dev: false
 
   /create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -2800,6 +2942,13 @@ packages:
 
   /dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+    dev: false
+
+  /dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+    dependencies:
+      '@babel/runtime': 7.23.9
+      csstype: 3.1.3
     dev: false
 
   /domexception@4.0.0:
@@ -3420,6 +3569,10 @@ packages:
     dependencies:
       to-regex-range: 5.0.1
 
+  /find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+    dev: false
+
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -3660,6 +3813,12 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
+
+  /hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+    dependencies:
+      react-is: 16.13.1
+    dev: false
 
   /html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
@@ -4656,6 +4815,10 @@ packages:
     dependencies:
       tmpl: 1.0.5
 
+  /memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+    dev: false
+
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -4978,7 +5141,6 @@ packages:
   /path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
-    dev: true
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
@@ -5124,7 +5286,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
-    dev: true
 
   /proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
@@ -5161,7 +5322,6 @@ packages:
 
   /react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-    dev: true
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -5194,6 +5354,27 @@ packages:
       react: 18.2.0
     dev: false
 
+  /react-select@5.8.0(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.23.9
+      '@emotion/cache': 11.11.0
+      '@emotion/react': 11.11.4(react@18.2.0)
+      '@floating-ui/dom': 1.6.3
+      '@types/react-transition-group': 4.4.10
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-transition-group: 4.4.5(react-dom@18.2.0)(react@18.2.0)
+      use-isomorphic-layout-effect: 1.1.2(react@18.2.0)
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
   /react-shallow-renderer@16.15.0(react@18.2.0):
     resolution: {integrity: sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==}
     peerDependencies:
@@ -5213,6 +5394,20 @@ packages:
       react-is: 18.2.0
       react-shallow-renderer: 16.15.0(react@18.2.0)
       scheduler: 0.23.0
+    dev: false
+
+  /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+    dependencies:
+      '@babel/runtime': 7.23.9
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:
@@ -5481,6 +5676,11 @@ packages:
       source-map: 0.6.1
     dev: false
 
+  /source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -5627,6 +5827,10 @@ packages:
       '@babel/core': 7.23.9
       client-only: 0.0.1
       react: 18.2.0
+    dev: false
+
+  /stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
     dev: false
 
   /sucrase@3.35.0:
@@ -5911,6 +6115,18 @@ packages:
       requires-port: 1.0.0
     dev: false
 
+  /use-isomorphic-layout-effect@1.1.2(react@18.2.0):
+    resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      react: 18.2.0
+    dev: false
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
@@ -6072,6 +6288,11 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  /yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /yaml@2.3.4:
     resolution: {integrity: sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==}

--- a/src/app/components/InterventionDetails.jsx
+++ b/src/app/components/InterventionDetails.jsx
@@ -1,11 +1,11 @@
 'use client'
 /* eslint-disable no-unused-vars */
 import React from 'react'
+/* eslint-enable no-unused-vars */
 import Image from 'next/image'
 import ButtonIcon from './buttonIcon'
-/* eslint-enable no-unused-vars */
 
-export default function InterventionDetails() {
+export default function InterventionDetails({ intervention }) {
 	return (
 		<div className="flex flex-col gap-5 bg-gray-50 rounded-xl p-10 drop-shadow-lg border border-gray-300">
 			<div className="flex gap-3 justify-end w-full">
@@ -34,38 +34,44 @@ export default function InterventionDetails() {
 				</h1>
 			</div>
 			<hr></hr>
-			<div className="flex flex-col gap-3">
-				<p className="font-Varela text-gray-800">
-					<span className="font-Varela text-blue-500 font-bold mr-2">
-						Fecha de atención:
-					</span>
-					01/01/2000
-				</p>
-				<p className="font-Varela text-gray-800">
-					<span className="font-Varela text-blue-500 font-bold mr-2">
-						Tipología:
-					</span>
-					Dermatologo
-				</p>
-				<p className="font-Varela text-gray-800">
-					<span className="font-Varela text-blue-500 font-bold mr-2">
-						Técnico:
-					</span>
-					Manuel García
-				</p>
-				<p className="font-Varela text-gray-800">
-					<span className="font-Varela text-blue-500 font-bold mr-2">
-						Motivo:
-					</span>
-					Caida del tercer piso
-				</p>
-				<p className="font-Varela text-gray-800">
-					<p className="font-Varela text-blue-500 font-bold mr-2">
-						Observaciones:
+			{intervention && (
+				<div className="flex flex-col gap-3">
+					<p className="font-Varela text-gray-800">
+						<span className="font-Varela text-blue-500 font-bold mr-2">
+							Fecha de atención:
+						</span>
+						{intervention.date}
 					</p>
-					- Presenta fractura en la pierna derecha.
-				</p>
-			</div>
+					<p className="font-Varela text-gray-800">
+						<span className="font-Varela text-blue-500 font-bold mr-2">
+							Tipología:
+						</span>
+						{intervention.typology}
+					</p>
+					<p className="font-Varela text-gray-800">
+						<span className="font-Varela text-blue-500 font-bold mr-2">
+							Técnico:
+						</span>
+						{intervention.technician}
+					</p>
+					<p className="font-Varela text-gray-800">
+						<span className="font-Varela text-blue-500 font-bold mr-2">
+							Motivo:
+						</span>
+						{intervention.reason}
+					</p>
+					<div className="font-Varela text-gray-800">
+						<span className="font-Varela text-blue-500 font-bold mr-2">
+							Observaciones:
+						</span>
+						<textarea
+							className="resize-none w-full h-40 overflow-y-auto border border-gray-400 rounded-md p-2"
+							readOnly
+							value={intervention.observations}
+						/>
+					</div>
+				</div>
+			)}
 		</div>
 	)
 }

--- a/src/app/components/cardIntervention.jsx
+++ b/src/app/components/cardIntervention.jsx
@@ -4,11 +4,11 @@ import React from 'react'
 import Tag from './tag'
 
 export default function CardIntervention({ intervention, handleClick }) {
-	const dateIntervention = new Date(intervention.intervention_date)
+	const dateIntervention = new Date(intervention.date)
 		.toLocaleString()
 		.split(',')[0]
 
-	const hourIntervention = new Date(intervention.intervention_date)
+	const hourIntervention = new Date(intervention.date)
 		.toLocaleTimeString('es-ES', {
 			hour12: false,
 			hour: '2-digit',
@@ -34,10 +34,10 @@ export default function CardIntervention({ intervention, handleClick }) {
 				</svg>
 			</div>
 			<div className="flex flex-col justify-between w-full">
-				<strong className="text-xl">{intervention.patient}</strong>
+				<strong className="text-xl">{intervention.patient.name}</strong>
 				<div className={'flex justify-end gap-2 mt-2'}>
 					{/* Add tags with following format */}
-					{intervention.intervention_date && (
+					{intervention.date && (
 						<>
 							<Tag
 								svg={

--- a/src/app/components/searchbar.jsx
+++ b/src/app/components/searchbar.jsx
@@ -6,7 +6,12 @@ import React from 'react'
 import ButtonIcon from './buttonIcon'
 import ButtonText from './buttonText'
 
-const Searchbar = () => {
+const Searchbar = ({
+	text = 'Dar de alta',
+	handleClick = () => {
+		console.log('Funciona')
+	}
+}) => {
 	return (
 		<div className="flex w-full justify-end pt-3 self-start sticky top-0 left-0 bg-white">
 			<div className="flex justify-around items-center md:w-full w-5/6 p-3 gap-1">
@@ -22,11 +27,16 @@ const Searchbar = () => {
 				</div>
 				<ButtonIcon color={'bg-blue-500'} iconpath={'/filter.svg'} />
 				<div className="lg:hidden block">
-					<ButtonIcon color={'bg-[#75AF73]'} iconpath={'/plus.svg'} />
+					<ButtonIcon
+						color={'bg-[#75AF73]'}
+						iconpath={'/plus.svg'}
+						handleClick={handleClick}
+					/>
 				</div>
 				<div className="lg:block hidden">
 					<ButtonText
-						text={'Dar de alta'}
+						text={text}
+						handleClick={handleClick}
 						px={'md:px-3'}
 						isRounded={true}
 						color={'bg-[#75AF73]'}

--- a/src/app/exportData.js
+++ b/src/app/exportData.js
@@ -1,6 +1,6 @@
 import exportFromJSON from 'export-from-json'
 
-export function exportData(datos, nombre, columnas) {
+export default function exportData(datos, nombre, columnas) {
 	try {
 		exportFromJSON({
 			data: datos,

--- a/src/app/interventions/RegisterInterventionModal.jsx
+++ b/src/app/interventions/RegisterInterventionModal.jsx
@@ -1,82 +1,83 @@
-/* eslint-disable no-unused-vars */
 'use client'
+/* eslint-disable no-unused-vars */
+import React, { useState } from 'react'
+/* eslint-enable no-unused-vars */
 import Pen3 from '../components/icons/pen-3'
 import User from '../components/icons/user'
 import UserLaptop from '../components/icons/user-laptop'
 import Clipboard from '../components/icons/clipboard'
+import axios from 'axios'
 
-/* eslint-disable no-unused-vars */
-import React from 'react'
-import { useRouter } from 'next/navigation'
-import router from 'next/router'
-/* eslint-enable no-unused-vars */
+function RegisterInterventionModal({ onClickFunction }) {
+	// if (!isVisible) return null
+	const [formData, setFormData] = useState({
+		date: '',
+		reason: '',
+		typology: '',
+		observations: '',
+		patient_id: '',
+		technician: ''
+	})
 
-// const axios = require('axios').default
-
-function RegisterInterventionModal({ isVisible, onClose }) {
-	if (!isVisible) return null
-
-	// const router = useRouter()
-	async function onSubmit(event) {
-		event.preventDefault()
-		// TODO: waiting for creation API implementation
-		// const formData = new FormData(event.target)
-		// axios
-		// 	.post(
-		// 		'https://65dc59f1e7edadead7ebb34d.mockapi.io/api/v1/interventions',
-		// 		formData
-		// 	)
-		// 	.then(function (response) {
-		// 		// Navigate to the newly created beneficiary
-		// 		router.push('/interventions/' + response.data.id.toString())
-		// 	})
-		// 	.catch(function (error) {
-		// 		// TODO: handle error
-		// 		console.log(error)
-		// 	})
+	const handleInputChange = e => {
+		const { name, value } = e.target
+		setFormData({ ...formData, [name]: value })
 	}
-	const closedModal = () => {
-		window.location.href = '/interventions'
+
+	const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
+
+	const handleAddIntervention = () => {
+		axios.post(`${BASEURL}/acat/intervention`, formData, {
+			headers: {
+				'Content-Type': 'application/json'
+			}
+		})
+		console.log('Datos del formulario:', formData)
 	}
 
 	return (
-		<div
-			className="fixed inset-0 bg-black bg-opacity-25 backdrop-blur-sm flex justify-center items-center z-30"
-			id="close"
-			onClick={closedModal}
-		>
-			<div className="w-96 p-8 bg-white rounded-xl space-y-6">
-				<button className="text-gray-500 text-xl l" onClick={onClose}>
-					X
-				</button>
+		<div className="fixed bg-gray-600 bg-opacity-50 h-full w-full flex font-Varela items-center justify-center z-50">
+			<div className="p-10 border h-fit shadow-lg rounded-xl bg-white max-h-full overflow-y-auto space-y-6">
+				<div className="flex justify-end">
+					<button
+						className="bg-red-500 text-white text-xl rounded-md shadow-lg w-[30px] h-[30px] mb-3"
+						onClick={onClickFunction}
+					>
+						X
+					</button>
+				</div>
 
 				<h1 className="text-center font-poppins text-2xl">
 					<strong>Registro de Intervenciones</strong>
 				</h1>
-				<form onSubmit={onSubmit} className="space-y-4">
+				<form className="space-y-4">
 					<div>
-						<label htmlFor="name" className="block">
+						<label className="block">
 							<strong>Nombre</strong>
 						</label>
 						<div className="flex items-center border-2 rounded-md border-gray-200 bg-white">
 							<User height="18" width="18" />
 							<input
 								type="text"
-								name="name"
+								name="patient_id"
+								value={formData.patient_id}
+								onChange={handleInputChange}
 								placeholder="Usuario"
 								className="p-1 w-full"
 							/>
 						</div>
 					</div>
 					<div>
-						<label htmlFor="tipologia" className="block">
+						<label className="block">
 							<strong>Tipologia</strong>
 						</label>
 						<div className="flex items-center border-2 rounded-md border-gray-200 bg-white">
 							<Pen3 />
 							<input
 								type="text"
-								name="Tipologia"
+								name="typology"
+								value={formData.tipology}
+								onChange={handleInputChange}
 								placeholder="tipologia"
 								className="p-1 w-full"
 							/>
@@ -87,7 +88,13 @@ function RegisterInterventionModal({ isVisible, onClose }) {
 							<strong>Fecha de atencion</strong>
 						</label>
 						<div className="flex items-center border-2 rounded-md border-gray-200 bg-white">
-							<input type="date" name="birthdate" className="p-1 w-full" />
+							<input
+								type="date"
+								name="date"
+								value={formData.date}
+								onChange={handleInputChange}
+								className="p-1 w-full"
+							/>
 						</div>
 					</div>
 					<div>
@@ -99,6 +106,8 @@ function RegisterInterventionModal({ isVisible, onClose }) {
 							<input
 								type="text"
 								name="technician"
+								value={formData.technician}
+								onChange={handleInputChange}
 								placeholder="Técnico que lo ha atendido"
 								className="p-1 w-full"
 							/>
@@ -112,7 +121,9 @@ function RegisterInterventionModal({ isVisible, onClose }) {
 							<Clipboard />
 							<input
 								type="text"
-								name="observations"
+								name="reason"
+								value={formData.reason}
+								onChange={handleInputChange}
 								placeholder="Observaciones sobre el beneficiario"
 								className="p-1 w-full"
 							/>
@@ -127,18 +138,22 @@ function RegisterInterventionModal({ isVisible, onClose }) {
 							<input
 								type="text"
 								name="observations"
+								value={formData.observations}
+								onChange={handleInputChange}
 								placeholder="Motivo"
 								className="p-1 w-full"
 							/>
 						</div>
 					</div>
-					<button
-						type="submit"
-						className="bg-blue-600 rounded-md drop-shadow-lg p-2 cursor-pointer text-white w-full"
-						onClick={closedModal}
-					>
-						Registrar
-					</button>
+					<div className="flex justify-center w-full mt-6">
+						<button
+							type="submit"
+							className="bg-green-500 rounded-md drop-shadow-lg p-2 cursor-pointer text-white w-full"
+							onClick={handleAddIntervention}
+						>
+							Registrar
+						</button>
+					</div>
 				</form>
 			</div>
 		</div>

--- a/src/app/interventions/[interventionId]/fetch.js
+++ b/src/app/interventions/[interventionId]/fetch.js
@@ -1,10 +1,11 @@
 import axios from 'axios'
-export function fetchDataIntervention(interventionId) {
-	const intervention = axios.get(
-		'https://65df8753ff5e305f32a26916.mockapi.io/Interventions/interventions' +
-			interventionId
-	)
-	return intervention.then(response => {
-		return response.data
-	})
+export async function fetchDataIntervention(interventionId) {
+	const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
+	try{
+		const intervention = await axios.get(`${BASEURL}/acat/intervention/${interventionId}`)
+		return intervention.data
+	}
+	catch (error) {
+		return null
+	}
 }

--- a/src/app/interventions/[interventionId]/page.jsx
+++ b/src/app/interventions/[interventionId]/page.jsx
@@ -1,16 +1,35 @@
+'use client'
+/* eslint-disable no-unused-vars */
+import React, { Suspense, useEffect, useState } from 'react'
+/* eslint-enable no-unused-vars */
 import InterventionDetails from '../../components/InterventionDetails'
 import Sidebar from '../../components/sidebar'
-/* eslint-disable no-unused-vars */
-import React, { Suspense } from 'react'
-/* eslint-enable no-unused-vars */
-export default function Page() {
+import { fetchDataIntervention } from './fetch'
+
+export default function Page({ params }) {
+	const [intervention, setIntervention] = useState(null)
+
+	useEffect(() => {
+		const fetchData = async () => {
+			try {
+				const intervention = await fetchDataIntervention(params.interventionId)
+				setIntervention(intervention)
+			} catch (error) {
+				console.error('Error al cargar los datos:', error)
+				alert(
+					'Se produjo un error al cargar los datos. Por favor, inténtalo de nuevo.'
+				)
+			}
+		}
+		fetchData()
+	}, [])
 	return (
 		<main className="flex bg-white wallpaper w-screen h-screen text-black">
 			<Suspense fallback={<div></div>}>
 				<Sidebar className="relative" />
 			</Suspense>
 			<div className="w-full h-full flex items-center justify-center">
-				<InterventionDetails />
+				<InterventionDetails intervention={intervention} />
 			</div>
 		</main>
 	)

--- a/src/app/interventions/fetchIntervention.js
+++ b/src/app/interventions/fetchIntervention.js
@@ -3,7 +3,7 @@ export async function fetchDataInterventions() {
 	const BASEURL = process.env.NEXT_PUBLIC_BASE_URL
 	try{
 		const interventions = await axios.get(
-			`${BASEURL}/acat/appointment/`
+			`${BASEURL}/acat/intervention`
 		)
 		return interventions.data
 	}

--- a/src/app/interventions/page.jsx
+++ b/src/app/interventions/page.jsx
@@ -10,6 +10,7 @@ import { fetchDataInterventions } from './fetchIntervention'
 import Image from 'next/image'
 import exportData from '../exportData'
 import axios from 'axios'
+import RegisterInterventionModal from './RegisterInterventionModal'
 
 export default function InterventionPage() {
 	const [data, setData] = useState(null)
@@ -97,13 +98,15 @@ export default function InterventionPage() {
 									<CardIntervention
 										key={intervention.id}
 										intervention={intervention}
-										handleClick={toggleModal}
 									/>
 								</Link>
 							))}
 					</Suspense>
 				</div>
 			</div>
+			{showModal ? (
+				<RegisterInterventionModal onClickFunction={toggleModal} />
+			) : null}
 		</main>
 	)
 }


### PR DESCRIPTION
# Description

In this PR, the error that did not allow to visualise the modal to create an intervention has been corrected, and the view to show all the interventions and their corresponding details has been connected to the backend.

To show the details of the interventions, the field showing the remarks has been modified, because when you show a very large text it did not fit.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
