### PR TITLE
Fix/56 fix sidebar links to creation

### DIFF
--- a/src/app/components/LoginForm.jsx
+++ b/src/app/components/LoginForm.jsx
@@ -15,7 +15,7 @@ function LoginForm() {
 	const router = useRouter()
 
 	const isMobile = () => {
-		return window.innerWidth <= 768
+		return typeof window !== 'undefined' ? window.innerWidth <= 768 : false
 	}
 
 	async function onSubmit(event) {

--- a/src/app/components/LoginForm.jsx
+++ b/src/app/components/LoginForm.jsx
@@ -14,6 +14,10 @@ function LoginForm() {
 	}
 	const router = useRouter()
 
+	const isMobile = () => {
+		return window.innerWidth <= 768
+	}
+
 	async function onSubmit(event) {
 		event.preventDefault()
 		const formData = new FormData(event.target)
@@ -23,7 +27,8 @@ function LoginForm() {
 			.then(function (response) {
 				document.cookie = `access_token=${response.data.access_token}; Secure; HttpOnly; SameSite=Strict`
 				document.cookie = `refresh_token=${response.data.refresh_token}; Secure; HttpOnly; SameSite=Strict`
-				router.push('/beneficiaries')
+				const stateSidebar = isMobile() ? 'false' : 'true'
+				router.push(`/beneficiaries?showSidebar=${stateSidebar}`)
 			})
 			.catch(function (error) {
 				alert('Error al iniciar sesión: ' + error.response.data.detail)

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -20,12 +20,6 @@ export default function Sidebar() {
 		},
 		{
 			link: '',
-			icon: '/square-plus.svg',
-			text: 'Dar de alta',
-			subentry: true
-		},
-		{
-			link: '',
 			icon: '/bye.svg',
 			text: 'Finalizados',
 			subentry: true
@@ -34,12 +28,6 @@ export default function Sidebar() {
 			link: '/interventions',
 			icon: '/calendar.svg',
 			text: 'Intervenciones'
-		},
-		{
-			link: '/',
-			icon: '/square-plus.svg',
-			text: 'Crear intervención',
-			subentry: true
 		},
 		{
 			link: '',

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -13,7 +13,7 @@ export default function Sidebar() {
 	const { replace } = useRouter()
 
 	const isMobile = () => {
-		return window.innerWidth <= 768
+		return typeof window !== 'undefined' ? window.innerWidth <= 768 : false
 	}
 
 	const initialState = isMobile() ? 'false' : 'true'

--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -12,9 +12,15 @@ export default function Sidebar() {
 	const pathname = usePathname()
 	const { replace } = useRouter()
 
+	const isMobile = () => {
+		return window.innerWidth <= 768
+	}
+
+	const initialState = isMobile() ? 'false' : 'true'
+
 	const links = [
 		{
-			link: '/beneficiaries',
+			link: `/beneficiaries?showSidebar=${initialState}`,
 			icon: '/family.svg',
 			text: 'Beneficiarios'
 		},
@@ -25,7 +31,7 @@ export default function Sidebar() {
 			subentry: true
 		},
 		{
-			link: '/interventions',
+			link: `/interventions?showSidebar=${initialState}`,
 			icon: '/calendar.svg',
 			text: 'Intervenciones'
 		},
@@ -35,7 +41,7 @@ export default function Sidebar() {
 			text: 'Usuarios'
 		},
 		{
-			link: '/create-user',
+			link: `/create-user?showSidebar=${initialState}`,
 			icon: '/face-plus.svg',
 			text: 'Crear nuevo usuario',
 			subentry: true


### PR DESCRIPTION
# Description

Delete links to modal and add function to change sidebar status depending on screen layout. When you change the screen size it is not automatically hidden or displayed but when you navigate from the sidebar to that endpoint with that screen size it will be hidden or displayed.

# How Has This Been Tested?
Testing informal.

- [x] See that the sidebar is hidden and displayed when browsing on different screen sizes.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes