### PR TITLE
Hotfix/87 Fix password link

### DIFF
--- a/src/app/components/sidebar.jsx
+++ b/src/app/components/sidebar.jsx
@@ -36,7 +36,7 @@ export default function Sidebar() {
 			text: 'Intervenciones'
 		},
 		{
-			link: 'passwords',
+			link: '/passwords',
 			icon: '/bell.svg',
 			text: 'Cambiar contraseña'
 		},


### PR DESCRIPTION
# Description

Fixed an error when navigating to the password management page from a beneficiary detail page using the sidebar

